### PR TITLE
fix pass not defined error

### DIFF
--- a/systems/effects.js
+++ b/systems/effects.js
@@ -308,7 +308,7 @@ AFRAME.registerSystem("effects", {
             }
             if (obj.pass) {
                 pickup();
-                passes.push({ pass: pass, behavior: obj } );
+                passes.push({ pass: obj.pass, behavior: obj } );
             } else if (obj.material){
                 pickup();
                 passes.push({ pass: makepass(obj.material, false, obj.vr), behavior: obj });


### PR DESCRIPTION
This was giving me runtime errors when I created an effect which used the .pass parameter. Figured it must have been a bug.