### PR TITLE
Fix lut texture in colors component

### DIFF
--- a/components/colors/index.js
+++ b/components/colors/index.js
@@ -35,7 +35,7 @@ AFRAME.registerComponent("colors", {
             "red": { type: "v3", value: null },
             "green": { type: "v3", value: null },
             "blue": { type: "v3", value: null },
-            "texture": { type: "t", value: null}
+            "texture": { type: "t", value: new THREE.Texture() }
         }
         
         this.rebuild();
@@ -55,8 +55,9 @@ AFRAME.registerComponent("colors", {
         }
 
         if(this.data.lut !== oldData.lut) {
-            if(this.uniforms.texture.value) this.uniforms.texture.value.dispose();
-            this.uniforms.texture.value = new THREE.Texture(this.data.lut);
+            const texture = this.uniforms.texture.value;
+            texture.image = this.data.lut;
+            texture.needsUpdate = true;
         }
     },
 

--- a/components/colors/index.js
+++ b/components/colors/index.js
@@ -35,7 +35,16 @@ AFRAME.registerComponent("colors", {
             "red": { type: "v3", value: null },
             "green": { type: "v3", value: null },
             "blue": { type: "v3", value: null },
-            "texture": { type: "t", value: new THREE.Texture() }
+            "texture": { 
+                type: "t", 
+                value: new THREE.Texture(
+                    undefined, // Default Image
+                    undefined, // Default Mapping
+                    undefined, // Default wrapS
+                    undefined, // Default wrapT
+                    THREE.NearestFilter, // magFilter
+                    THREE.NearestFilter  // minFilter
+                )}
         }
         
         this.rebuild();


### PR DESCRIPTION
The lut texture wasnt working for me in the colors component for a couple of reasons.

Firstly 'new THREE.Texture(img)' doesn't create a working texture for some reason. Have to do:
const t = new THREE.Texture();
t.image = img;
t.needsUpdate = true;

And lastly the texture min/mag filters must be set to Nearest or the Lut has some weird artifacts.